### PR TITLE
bump shell version so it works for gnome-shell 41 out of the box

### DIFF
--- a/transparent-shell@siroj42.github.io/metadata.json
+++ b/transparent-shell@siroj42.github.io/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Make the main shell components (Top bar, dash, workspace view) transparent.",
   "name": "Transparent Shell",
-  "shell-version": ["40"],
+  "shell-version": ["41"],
   "url": "https://github.com/Siroj42/gnome-extension-transparent-shell",
   "uuid": "transparent-shell@siroj42.github.io",
   "version": 7


### PR DESCRIPTION
Lets bump the shell version so it supports gnome-shell 41 out of the box instead of the users manually bumping it after install.