### PR TITLE
Add support for Gnome 42

### DIFF
--- a/transparent-shell@siroj42.github.io/extension.js
+++ b/transparent-shell@siroj42.github.io/extension.js
@@ -59,82 +59,25 @@ const componentToggles = {
     toggleTransparency(Main.overview.searchEntry, isEnabled),
 };
 
+const onChange = (_, key) => {
+  const isEnabled = settings.get_boolean(key);
+  if (componentToggles[key]) {
+    componentToggles[key](isEnabled);
+  }
+};
+
 function enable() {
   Object.keys(settingskeys).forEach((key) => {
     if (settings.get_boolean(key)) {
-      enable_fkt(key);
+      componentToggles[key](true);
     }
-    settingskeys[key] = settings.connect("changed::" + key, someChange);
+    settingskeys[key] = settings.connect("changed::" + key, onChange);
   });
 }
 
 function disable() {
   Object.keys(settingskeys).forEach((key) => {
-    disable_fkt(key);
+    componentToggles[key](false);
     settings.disconnect(settingskeys[key]);
   });
-}
-
-function someChange(_, key) {
-  if (settings.get_boolean(key)) {
-    enable_fkt(key);
-  } else {
-    disable_fkt(key);
-  }
-}
-
-function enable_fkt(key) {
-  switch (key) {
-    case "top-panel":
-      Main.panel.add_style_class_name("shell-transparency");
-      Main.panel._leftCorner.add_style_class_name("shell-transparency");
-      Main.panel._rightCorner.add_style_class_name("shell-transparency");
-      try {
-        Main.mmPanel.forEach((mmpanel) => {
-          mmpanel.add_style_class_name("shell-transparency");
-          mmpanel._leftCorner.add_style_class_name("shell-transparency");
-          mmpanel._rightCorner.add_style_class_name("shell-transparency");
-        });
-      } catch (error) {
-        log(error);
-      }
-      break;
-    case "dash":
-      Main.overview.dash._background.add_style_class_name("shell-transparency");
-      break;
-    case "search":
-      Main.overview.searchEntry.add_style_class_name("search-transparency");
-      break;
-    default:
-      return;
-  }
-}
-
-function disable_fkt(key) {
-  switch (key) {
-    case "top-panel":
-      Main.panel.remove_style_class_name("shell-transparency");
-      Main.panel._leftCorner.remove_style_class_name("shell-transparency");
-      Main.panel._rightCorner.remove_style_class_name("shell-transparency");
-      try {
-        Main.mmPanel.forEach((mmpanel) => {
-          mmpanel.remove_style_class_name("shell-transparency");
-          mmpanel._leftCorner.remove_style_class_name("shell-transparency");
-          mmpanel._rightCorner.remove_style_class_name("shell-transparency");
-        });
-      } catch (error) {
-        log(error);
-      }
-      break;
-    case "dash":
-      Main.overview.dash._background.remove_style_class_name(
-        "shell-transparency"
-      );
-      break;
-    case "search":
-      Main.overview.searchEntry.remove_style_class_name("search-transparency");
-      break;
-    default:
-      return;
-  }
 }

--- a/transparent-shell@siroj42.github.io/extension.js
+++ b/transparent-shell@siroj42.github.io/extension.js
@@ -4,20 +4,20 @@ const ExtensionUtils = imports.misc.extensionUtils;
 
 const Extension = ExtensionUtils.getCurrentExtension();
 
-let gschema = Gio.SettingsSchemaSource.new_from_directory(
+const gschema = Gio.SettingsSchemaSource.new_from_directory(
   Extension.dir.get_child("schemas").get_path(),
   Gio.SettingsSchemaSource.get_default(),
   false
 );
 
-let settings = new Gio.Settings({
+const settings = new Gio.Settings({
   settings_schema: gschema.lookup(
     "org.gnome.shell.extensions.transparent-shell",
     true
   ),
 });
 
-let settingskeys = {
+const settingskeys = {
   "top-panel": 0,
   dash: 0,
   search: 0,

--- a/transparent-shell@siroj42.github.io/extension.js
+++ b/transparent-shell@siroj42.github.io/extension.js
@@ -38,11 +38,14 @@ const toggleTransparency = (el, enabled = true) =>
 const componentToggles = {
   "top-panel": (isEnabled) => {
     try {
-      [Main.panel, ...Main.mmPanel].forEach((mmpanel) => {
-        toggleTransparency(mmpanel, isEnabled);
-        toggleTransparency(mmpanel._leftCorner, isEnabled);
-        toggleTransparency(mmpanel._rightCorner, isEnabled);
-      });
+      [Main.panel]
+        .concat(Main?.mmPanel)
+        .filter((p) => !!p)
+        .forEach((mmpanel) => {
+          toggleTransparency(mmpanel, isEnabled);
+          toggleTransparency(mmpanel._leftCorner, isEnabled);
+          toggleTransparency(mmpanel._rightCorner, isEnabled);
+        });
     } catch (error) {
       log(error);
     }

--- a/transparent-shell@siroj42.github.io/extension.js
+++ b/transparent-shell@siroj42.github.io/extension.js
@@ -23,9 +23,19 @@ const settingskeys = {
   search: 0,
 };
 
+const SHELL_TRANSPARENCY = "shell-transparency";
+
 function init() {
   log("Starting transparent-shell extension");
 }
+
+const toggleTransparency = (el, enabled = true) => {
+  if (el) {
+    el[enabled ? "add_style_class_name" : "remove_style_class_name"](
+      SHELL_TRANSPARENCY
+    );
+  }
+};
 
 function enable() {
   Object.keys(settingskeys).forEach((key) => {

--- a/transparent-shell@siroj42.github.io/extension.js
+++ b/transparent-shell@siroj42.github.io/extension.js
@@ -29,25 +29,19 @@ function init() {
   log("Starting transparent-shell extension");
 }
 
-const toggleTransparency = (el, enabled = true) => {
-  if (el) {
-    el[enabled ? "add_style_class_name" : "remove_style_class_name"](
-      SHELL_TRANSPARENCY
-    );
-  }
-};
+const toggleTransparency = (el, enabled = true) =>
+  el &&
+  el[enabled ? "add_style_class_name" : "remove_style_class_name"](
+    SHELL_TRANSPARENCY
+  );
 
 const componentToggles = {
   "top-panel": (isEnabled) => {
     try {
       [Main.panel, ...Main.mmPanel].forEach((mmpanel) => {
         toggleTransparency(mmpanel, isEnabled);
-        if (mmpanel._leftCorner) {
-          toggleTransparency(mmpanel._leftCorner, isEnabled);
-        }
-        if (mmpanel._rightCorner) {
-          toggleTransparency(mmpanel._rightCorner, isEnabled);
-        }
+        toggleTransparency(mmpanel._leftCorner, isEnabled);
+        toggleTransparency(mmpanel._rightCorner, isEnabled);
       });
     } catch (error) {
       log(error);

--- a/transparent-shell@siroj42.github.io/extension.js
+++ b/transparent-shell@siroj42.github.io/extension.js
@@ -37,6 +37,28 @@ const toggleTransparency = (el, enabled = true) => {
   }
 };
 
+const componentToggles = {
+  "top-panel": (isEnabled) => {
+    try {
+      [Main.panel, ...Main.mmPanel].forEach((mmpanel) => {
+        toggleTransparency(mmpanel, isEnabled);
+        if (mmpanel._leftCorner) {
+          toggleTransparency(mmpanel._leftCorner, isEnabled);
+        }
+        if (mmpanel._rightCorner) {
+          toggleTransparency(mmpanel._rightCorner, isEnabled);
+        }
+      });
+    } catch (error) {
+      log(error);
+    }
+  },
+  dash: (isEnabled) =>
+    toggleTransparency(Main.overview.dash._background, isEnabled),
+  search: (isEnabled) =>
+    toggleTransparency(Main.overview.searchEntry, isEnabled),
+};
+
 function enable() {
   Object.keys(settingskeys).forEach((key) => {
     if (settings.get_boolean(key)) {

--- a/transparent-shell@siroj42.github.io/extension.js
+++ b/transparent-shell@siroj42.github.io/extension.js
@@ -5,108 +5,104 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Extension = ExtensionUtils.getCurrentExtension();
 
 let gschema = Gio.SettingsSchemaSource.new_from_directory(
-    Extension.dir.get_child('schemas').get_path(),
-    Gio.SettingsSchemaSource.get_default(),
-    false
+  Extension.dir.get_child("schemas").get_path(),
+  Gio.SettingsSchemaSource.get_default(),
+  false
 );
 
 let settings = new Gio.Settings({
-    settings_schema: gschema.lookup('org.gnome.shell.extensions.transparent-shell', true)
+  settings_schema: gschema.lookup(
+    "org.gnome.shell.extensions.transparent-shell",
+    true
+  ),
 });
 
 let settingskeys = {
-    "top-panel": 0,
-    "dash": 0,
-    "search": 0,
-}
+  "top-panel": 0,
+  dash: 0,
+  search: 0,
+};
 
-
-function init(){
-    log("Starting transparent-shell extension");
+function init() {
+  log("Starting transparent-shell extension");
 }
 
 function enable() {
-    Object.keys(settingskeys).forEach(key => {
-        if (settings.get_boolean(key)) {
-            enable_fkt(key);
-        }
-        settingskeys[key] = settings.connect(
-            'changed::'+key,
-            someChange
-        );
-    });
+  Object.keys(settingskeys).forEach((key) => {
+    if (settings.get_boolean(key)) {
+      enable_fkt(key);
+    }
+    settingskeys[key] = settings.connect("changed::" + key, someChange);
+  });
 }
 
 function disable() {
-    Object.keys(settingskeys).forEach(key => {
-        disable_fkt(key);
-        settings.disconnect(settingskeys[key]);
-    });
+  Object.keys(settingskeys).forEach((key) => {
+    disable_fkt(key);
+    settings.disconnect(settingskeys[key]);
+  });
 }
 
-
-
-function someChange(_,key){
-    if(settings.get_boolean(key)){
-        enable_fkt(key);
-    }else{
-        disable_fkt(key);
-    }
+function someChange(_, key) {
+  if (settings.get_boolean(key)) {
+    enable_fkt(key);
+  } else {
+    disable_fkt(key);
+  }
 }
 
-
-function enable_fkt(key){
-    switch (key) {
-        case "top-panel":
-            Main.panel.add_style_class_name('shell-transparency');
-            Main.panel._leftCorner.add_style_class_name('shell-transparency');
-            Main.panel._rightCorner.add_style_class_name('shell-transparency');
-            try {
-                Main.mmPanel.forEach(mmpanel => {
-                    mmpanel.add_style_class_name('shell-transparency');
-                    mmpanel._leftCorner.add_style_class_name('shell-transparency');
-                    mmpanel._rightCorner.add_style_class_name('shell-transparency');
-                });
-            } catch (error) {
-                log(error);
-            }
-            break;
-        case "dash":
-            Main.overview.dash._background.add_style_class_name('shell-transparency');
-            break;
-        case "search":
-            Main.overview.searchEntry.add_style_class_name("search-transparency");
-            break;
-        default:
-            return;
-    }
+function enable_fkt(key) {
+  switch (key) {
+    case "top-panel":
+      Main.panel.add_style_class_name("shell-transparency");
+      Main.panel._leftCorner.add_style_class_name("shell-transparency");
+      Main.panel._rightCorner.add_style_class_name("shell-transparency");
+      try {
+        Main.mmPanel.forEach((mmpanel) => {
+          mmpanel.add_style_class_name("shell-transparency");
+          mmpanel._leftCorner.add_style_class_name("shell-transparency");
+          mmpanel._rightCorner.add_style_class_name("shell-transparency");
+        });
+      } catch (error) {
+        log(error);
+      }
+      break;
+    case "dash":
+      Main.overview.dash._background.add_style_class_name("shell-transparency");
+      break;
+    case "search":
+      Main.overview.searchEntry.add_style_class_name("search-transparency");
+      break;
+    default:
+      return;
+  }
 }
 
-
-
-function disable_fkt(key){
-    switch (key) {
-        case "top-panel":
-            Main.panel.remove_style_class_name('shell-transparency');
-            Main.panel._leftCorner.remove_style_class_name('shell-transparency');
-            Main.panel._rightCorner.remove_style_class_name('shell-transparency');
-            try {
-                Main.mmPanel.forEach(mmpanel => {
-                    mmpanel.remove_style_class_name('shell-transparency');
-                    mmpanel._leftCorner.remove_style_class_name('shell-transparency');
-                    mmpanel._rightCorner.remove_style_class_name('shell-transparency');
-                });
-            } catch (error) {
-                log(error);
-            }
-            break;
-        case "dash":
-            Main.overview.dash._background.remove_style_class_name('shell-transparency');
-            break;
-        case "search":
-            Main.overview.searchEntry.remove_style_class_name("search-transparency");
-            break;
-        default:
-            return;
-    }
+function disable_fkt(key) {
+  switch (key) {
+    case "top-panel":
+      Main.panel.remove_style_class_name("shell-transparency");
+      Main.panel._leftCorner.remove_style_class_name("shell-transparency");
+      Main.panel._rightCorner.remove_style_class_name("shell-transparency");
+      try {
+        Main.mmPanel.forEach((mmpanel) => {
+          mmpanel.remove_style_class_name("shell-transparency");
+          mmpanel._leftCorner.remove_style_class_name("shell-transparency");
+          mmpanel._rightCorner.remove_style_class_name("shell-transparency");
+        });
+      } catch (error) {
+        log(error);
+      }
+      break;
+    case "dash":
+      Main.overview.dash._background.remove_style_class_name(
+        "shell-transparency"
+      );
+      break;
+    case "search":
+      Main.overview.searchEntry.remove_style_class_name("search-transparency");
+      break;
+    default:
+      return;
+  }
 }

--- a/transparent-shell@siroj42.github.io/metadata.json
+++ b/transparent-shell@siroj42.github.io/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Make the main shell components (Top bar, dash, workspace view) transparent.",
   "name": "Transparent Shell",
-  "shell-version": ["40"],
+  "shell-version": ["40", "41", "42"],
   "url": "https://github.com/Siroj42/gnome-extension-transparent-shell",
   "uuid": "transparent-shell@siroj42.github.io",
   "version": 7


### PR DESCRIPTION
# Purpose
This PR enables the extension to run on Gnome 42. This has been tested on Arch Linux using the unofficial `gnome-unstable` [repository](https://gitlab.com/fabiscafe/gnome-unstable).

# Implementation 
In Gnome 42, a decision has been made to remove the rounded corners of the top bar. For more information, take a look at [this PR](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2151). This has been done for performance and optimization purposes. 

This PR adds a check to see if the `_leftCorner` and `_rightCorner` elements of the `Main.panel` and `Main.mmPanel`s are defined. If they are, the transparency class it attached and detached accordingly. 

I have also done some linting and a bit of refactoring to the extension's code to remove the repeated code and to make it somewhat cleaner. 

Feedback is welcome!