### PR TITLE
Update versions to include Gnome 43

### DIFF
--- a/transparent-shell@siroj42.github.io/metadata.json
+++ b/transparent-shell@siroj42.github.io/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Make the main shell components (Top bar, dash, workspace view) transparent.",
   "name": "Transparent Shell",
-  "shell-version": ["40", "41", "42"],
+  "shell-version": ["40", "41", "42", "43"],
   "url": "https://github.com/Siroj42/gnome-extension-transparent-shell",
   "uuid": "transparent-shell@siroj42.github.io",
   "settings-schema": "org.gnome.shell.extensions.transparent-shell",


### PR DESCRIPTION
Updated version to include Gnome 43. Works just fine on this version as far as I can determine.